### PR TITLE
Fix directory name in getting started tutorial

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -180,7 +180,7 @@ var mergeTrees = require('broccoli-merge-trees');
 
 // Specify the Sass and Coffeescript directories
 var sassDir = 'app/scss';
-var coffeeDir = 'app/coffeescript';
+var coffeeDir = 'app/coffee';
 
 // Tell Broccoli how we want the assets to be compiled
 var styles = compileSass([sassDir], 'app.scss', 'app.css');


### PR DESCRIPTION
In the [file tree](https://github.com/folz/broccoli-site/blob/master/app/index.html#L157) the folder is called `coffee/`, here you're using another name.
